### PR TITLE
Feature / platform.json can template calling scripts

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 libE-templater
 ==============
 
-Generate libEnsemble testing scripts from templates for a variety of HPC platforms.
+Generate libEnsemble testing environments from templates for a variety of HPC platforms.
 
 Requires Jinja:
 
@@ -9,9 +9,9 @@ https://jinja.palletsprojects.com/en/2.11.x/
 
 ``pip install Jinja2``
 
-Supported platforms are LCRC's Bebop, ALCF's Theta, NERSC's Cori, and
-OLCF's Summit. Specify any specific platform to generate a testing environment
-at runtime with any number of ``--bebop``, ``--theta``, ``--cori``, and ``--summit``.
+Supported platforms are LCRC's Bebop, ALCF's Theta, NERSC's Cori, OLCF's Summit, and PSC's Bridges.
+Specify any specific platform to generate a testing environment
+at runtime with any number of ``--bebop``, ``--theta``, ``--cori``, ``--summit``, and ``--bridges``.
 
 Currently generates testing environments for the Forces and WarpX scaling tests.
 Use ``--forces`` and ``--warpx``.
@@ -31,16 +31,16 @@ Usage
 
     ``./templater --cori --forces``
 
-Configuration
--------------
+Utility Structure
+-----------------
 
 The ``platforms`` directory contains platform-specific test configurations
-and templates in ``bebop``, ``cori``, ``summit``, and ``theta``, and platform-agnostic
+and templates in directories named after each platform and platform-agnostic
 configurations and templates in ``all``. Each of these directories contains
 sub-directories, templates, and configurations for each supported test. For example,
 ``platforms/bebop`` contains ``forces`` and ``warpx`` directories that match both supported tests,
 two different templates for submission scripts (used by both tests), and ``platform.json``,
-containing platform-specific submission script parameters.
+containing parameters universal to tests on that platform.
 
 As an example, ``platforms/bebop/forces`` contains both a ``stage`` directory
 and multiple ``.json`` files. Each ``.json`` file corresponds to a variant of ``forces``,
@@ -61,12 +61,24 @@ with different numbers of nodes, comm-types, etc. that can be tested on ``bebop`
 
 Once a test output directory has been created, the templater will run each
 batch script prefixed with "prepare" in the output directory. This is helpful
-for setting permissions on copied shell scripts or copying additional files around
-if necessary. These scripts should be placed in any ``stage`` directory to be
-copied over.
+for setting permissions on shell scripts or copying files to variant directories.
+These scripts should be placed in any ``stage`` directory to be copied over.
 
-Example
--------
+Adjusting Tests
+---------------
+
+Calling scripts and batch submission scripts are templated by parameters in test-specific
+``.json`` files and platform-specific ``platform.json`` files. Each file contains
+``"calling"`` and ``"submit"`` labels, corresponding to Jinja fields in the calling script
+and batch submission script templates respectively.
+
+Note the following about ``platform.json``:
+
+    1) Parameters specified in ``platform.json`` don't have to be universal for all test types. For instance, ``"nthreads": 1`` can be included and templated for each WarpX test, but doesn't have to appear in Forces templates.
+    2) Parameters in ``platform.json`` can also appear in test-specific configurations. Test configurations will override values from ``platform.json``.
+
+New Test Example
+----------------
 
 Suppose we want to define a new test ``"particles"``, only for Theta, with ``mpi_128-nodes``
 and ``multiprocess_64-nodes`` variants.

--- a/platforms/all/run_libe_forces.py
+++ b/platforms/all/run_libe_forces.py
@@ -15,8 +15,17 @@ from libensemble.tools import parse_args, save_libE_output, add_unique_random_st
 from libensemble import libE_logger
 from forces_support import test_libe_stats, test_ensemble_dir, check_log_exception
 
+{% if use_balsam is defined %}
 USE_BALSAM = {{ use_balsam }}
+{% else %}
+USE_BALSAM = False
+{% endif %}
+
+{% if persis_gen is defined %}
 PERSIS_GEN = {{ persis_gen }}
+{% else %}
+PERSIS_GEN = False
+{% endif %}
 
 if PERSIS_GEN:
     from libensemble.gen_funcs.persistent_uniform_sampling import persistent_uniform as gen_f

--- a/platforms/bebop/forces/MPI_central.json
+++ b/platforms/bebop/forces/MPI_central.json
@@ -1,17 +1,14 @@
 {
 	"calling": {
-		"use_balsam": false,
 		"persis_gen": false,
 		"mpi_exctr_args": "auto_resources=True, central_mode=True",
 		"num_sim_particles": 2.0e4,
-		"sim_max": 8,
 		"mpi_disable_mprobes": true,
 		"template": "run_libe_forces.py"
 	},
 
 	"submit": {
 		"num_workers": 4,
-		"num_nodes": 2,
 		"exports": ["export I_MPI_FABRICS=shm:tmi"],
 		"cmd_prefix": "srun --overcommit --ntasks $(($NUM_WORKERS+1)) --nodes=1",
 		"template": "base_submit_template"

--- a/platforms/bebop/forces/MPI_central.json
+++ b/platforms/bebop/forces/MPI_central.json
@@ -4,11 +4,13 @@
 		"mpi_exctr_args": "auto_resources=True, central_mode=True",
 		"num_sim_particles": 2.0e4,
 		"mpi_disable_mprobes": true,
+		"sim_max": "8",
 		"template": "run_libe_forces.py"
 	},
 
 	"submit": {
 		"num_workers": 4,
+		"num_nodes": 2,
 		"exports": ["export I_MPI_FABRICS=shm:tmi"],
 		"cmd_prefix": "srun --overcommit --ntasks $(($NUM_WORKERS+1)) --nodes=1",
 		"template": "base_submit_template"

--- a/platforms/bebop/forces/MPI_distrib.json
+++ b/platforms/bebop/forces/MPI_distrib.json
@@ -1,17 +1,14 @@
 {
     "calling": {
-        "use_balsam": false,
         "persis_gen": false,
         "mpi_exctr_args": "auto_resources=True, central_mode=False",
         "num_sim_particles": 2.0e4,
-        "sim_max": 8,
         "mpi_disable_mprobes": true,
         "template": "run_libe_forces.py"
     },
 
     "submit": {
     	"num_workers": 4,
-    	"num_nodes": 2,
     	"exports": ["export MANAGER_NODE=false",
     				"export I_MPI_FABRICS_LIST=tmi,tcp",
     				"export I_MPI_FALLBACK=1",

--- a/platforms/bebop/forces/MPI_distrib.json
+++ b/platforms/bebop/forces/MPI_distrib.json
@@ -4,11 +4,13 @@
         "mpi_exctr_args": "auto_resources=True, central_mode=False",
         "num_sim_particles": 2.0e4,
         "mpi_disable_mprobes": true,
+        "sim_max": "8",
         "template": "run_libe_forces.py"
     },
 
     "submit": {
     	"num_workers": 4,
+        "num_nodes": 2,
     	"exports": ["export MANAGER_NODE=false",
     				"export I_MPI_FABRICS_LIST=tmi,tcp",
     				"export I_MPI_FALLBACK=1",

--- a/platforms/bebop/forces/MPI_distrib_fail_sim.json
+++ b/platforms/bebop/forces/MPI_distrib_fail_sim.json
@@ -1,10 +1,8 @@
 {
     "calling": {
-        "use_balsam": false,
         "persis_gen": false,
         "mpi_exctr_args": "auto_resources=True, central_mode=False",
         "num_sim_particles": 2.0e4,
-        "sim_max": 8,
         "fail_on_sim": true,
         "mpi_disable_mprobes": true,
         "template": "run_libe_forces.py"
@@ -12,7 +10,6 @@
 
     "submit": {
     	"num_workers": 4,
-    	"num_nodes": 2,
     	"exports": ["export MANAGER_NODE=false",
     				"export I_MPI_FABRICS_LIST=tmi,tcp",
     				"export I_MPI_FALLBACK=1",

--- a/platforms/bebop/forces/MPI_distrib_fail_sim.json
+++ b/platforms/bebop/forces/MPI_distrib_fail_sim.json
@@ -5,11 +5,13 @@
         "num_sim_particles": 2.0e4,
         "fail_on_sim": true,
         "mpi_disable_mprobes": true,
+        "sim_max": "8",
         "template": "run_libe_forces.py"
     },
 
     "submit": {
     	"num_workers": 4,
+        "num_nodes": 2,
     	"exports": ["export MANAGER_NODE=false",
     				"export I_MPI_FABRICS_LIST=tmi,tcp",
     				"export I_MPI_FALLBACK=1",

--- a/platforms/bebop/forces/MPI_distrib_fail_submit.json
+++ b/platforms/bebop/forces/MPI_distrib_fail_submit.json
@@ -1,10 +1,8 @@
 {
     "calling": {
-        "use_balsam": false,
         "persis_gen": false,
         "mpi_exctr_args": "auto_resources=True, central_mode=False",
         "num_sim_particles": 2.0e4,
-        "sim_max": 8,
         "fail_on_submit": true,
         "mpi_disable_mprobes": true,
         "template": "run_libe_forces.py"
@@ -12,7 +10,6 @@
 
     "submit": {
     	"num_workers": 4,
-    	"num_nodes": 2,
     	"exports": ["export MANAGER_NODE=false",
     				"export I_MPI_FABRICS_LIST=tmi,tcp",
     				"export I_MPI_FALLBACK=1",

--- a/platforms/bebop/forces/MPI_distrib_fail_submit.json
+++ b/platforms/bebop/forces/MPI_distrib_fail_submit.json
@@ -5,11 +5,13 @@
         "num_sim_particles": 2.0e4,
         "fail_on_submit": true,
         "mpi_disable_mprobes": true,
+        "sim_max": "8",
         "template": "run_libe_forces.py"
     },
 
     "submit": {
     	"num_workers": 4,
+        "num_nodes": 2,
     	"exports": ["export MANAGER_NODE=false",
     				"export I_MPI_FABRICS_LIST=tmi,tcp",
     				"export I_MPI_FALLBACK=1",

--- a/platforms/bebop/forces/MPI_distrib_one_node.json
+++ b/platforms/bebop/forces/MPI_distrib_one_node.json
@@ -1,17 +1,14 @@
 {
     "calling": {
-        "use_balsam": false,
         "persis_gen": false,
         "mpi_exctr_args": "auto_resources=True, central_mode=False",
         "num_sim_particles": 2.0e4,
-        "sim_max": 8,
         "mpi_disable_mprobes": true,
         "template": "run_libe_forces.py"
     },
 
     "submit": {
     	"num_workers": 4,
-    	"num_nodes": 2,
     	"exports": ["export I_MPI_FABRICS_LIST=tmi,tcp",
     		 		"export I_MPI_FALLBACK=1"],
     	"cmd_prefix": "srun --ntasks $(($NUM_WORKERS+1))",

--- a/platforms/bebop/forces/MPI_distrib_one_node.json
+++ b/platforms/bebop/forces/MPI_distrib_one_node.json
@@ -4,11 +4,13 @@
         "mpi_exctr_args": "auto_resources=True, central_mode=False",
         "num_sim_particles": 2.0e4,
         "mpi_disable_mprobes": true,
+        "sim_max": "8",
         "template": "run_libe_forces.py"
     },
 
     "submit": {
     	"num_workers": 4,
+        "num_nodes": 2,
     	"exports": ["export I_MPI_FABRICS_LIST=tmi,tcp",
     		 		"export I_MPI_FALLBACK=1"],
     	"cmd_prefix": "srun --ntasks $(($NUM_WORKERS+1))",

--- a/platforms/bebop/forces/mproc.json
+++ b/platforms/bebop/forces/mproc.json
@@ -1,16 +1,13 @@
 {
     "calling": {
-        "use_balsam": false,
         "persis_gen": false,
         "mpi_exctr_args": "auto_resources=True, central_mode=True",
         "num_sim_particles": 2.0e4,
-        "sim_max": 8,
         "template": "run_libe_forces.py"
     },
 
     "submit": {
     	"num_workers": 4,
-    	"num_nodes": 2,
     	"cmd_suffix": "--comms local --nworkers $NUM_WORKERS > out.txt 2>&1",
     	"template": "base_submit_template"
     }

--- a/platforms/bebop/forces/mproc.json
+++ b/platforms/bebop/forces/mproc.json
@@ -3,11 +3,13 @@
         "persis_gen": false,
         "mpi_exctr_args": "auto_resources=True, central_mode=True",
         "num_sim_particles": 2.0e4,
+        "sim_max": "8",
         "template": "run_libe_forces.py"
     },
 
     "submit": {
     	"num_workers": 4,
+        "num_nodes": 2,
     	"cmd_suffix": "--comms local --nworkers $NUM_WORKERS > out.txt 2>&1",
     	"template": "base_submit_template"
     }

--- a/platforms/bebop/forces/mproc_central.json
+++ b/platforms/bebop/forces/mproc_central.json
@@ -1,17 +1,14 @@
 {
     "calling": {
-        "use_balsam": false,
         "persis_gen": false,
         "mpi_exctr_args": "auto_resources=False",
         "cores": 16,
         "num_sim_particles": 2.0e4,
-        "sim_max": 8,
         "template": "run_libe_forces.py"
     },
 
     "submit": {
     	"num_workers": 4,
-    	"num_nodes": 2,
     	"cmd_suffix": "--comms local --nworkers $NUM_WORKERS > out.txt 2>&1",
     	"template": "base_submit_template"
     }

--- a/platforms/bebop/forces/mproc_central.json
+++ b/platforms/bebop/forces/mproc_central.json
@@ -4,11 +4,13 @@
         "mpi_exctr_args": "auto_resources=False",
         "cores": 16,
         "num_sim_particles": 2.0e4,
+        "sim_max": "8",
         "template": "run_libe_forces.py"
     },
 
     "submit": {
     	"num_workers": 4,
+        "num_nodes": 2,
     	"cmd_suffix": "--comms local --nworkers $NUM_WORKERS > out.txt 2>&1",
     	"template": "base_submit_template"
     }

--- a/platforms/bebop/forces/mproc_distrib_one_node.json
+++ b/platforms/bebop/forces/mproc_distrib_one_node.json
@@ -3,11 +3,13 @@
         "persis_gen": false,
         "mpi_exctr_args": "auto_resources=True, central_mode=False",
         "num_sim_particles": 2.0e4,
+        "sim_max": "8",
         "template": "run_libe_forces.py"
     },
 
     "submit": {
     	"num_workers": 4,
+        "num_nodes": 2,
     	"exports": ["export I_MPI_FABRICS_LIST=tmi,tcp",
     				"export I_MPI_FALLBACK=1"],
     	"cmd_suffix": "--comms local --nworkers $NUM_WORKERS > out.txt 2>&1",

--- a/platforms/bebop/forces/mproc_distrib_one_node.json
+++ b/platforms/bebop/forces/mproc_distrib_one_node.json
@@ -1,16 +1,13 @@
 {
     "calling": {
-        "use_balsam": false,
         "persis_gen": false,
         "mpi_exctr_args": "auto_resources=True, central_mode=False",
         "num_sim_particles": 2.0e4,
-        "sim_max": 8,
         "template": "run_libe_forces.py"
     },
 
     "submit": {
     	"num_workers": 4,
-    	"num_nodes": 2,
     	"exports": ["export I_MPI_FABRICS_LIST=tmi,tcp",
     				"export I_MPI_FALLBACK=1"],
     	"cmd_suffix": "--comms local --nworkers $NUM_WORKERS > out.txt 2>&1",

--- a/platforms/bebop/forces/mproc_fail_sim.json
+++ b/platforms/bebop/forces/mproc_fail_sim.json
@@ -1,17 +1,14 @@
 {
     "calling": {
-        "use_balsam": false,
         "persis_gen": false,
         "mpi_exctr_args": "auto_resources=True, central_mode=True",
         "num_sim_particles": 2.0e4,
-        "sim_max": 8,
         "fail_on_sim": true,
         "template": "run_libe_forces.py"
     },
 
     "submit": {
     	"num_workers": 4,
-    	"num_nodes": 2,
     	"cmd_suffix": "--comms local --nworkers $NUM_WORKERS > out.txt 2>&1",
     	"template": "base_submit_template"
     }

--- a/platforms/bebop/forces/mproc_fail_sim.json
+++ b/platforms/bebop/forces/mproc_fail_sim.json
@@ -4,11 +4,13 @@
         "mpi_exctr_args": "auto_resources=True, central_mode=True",
         "num_sim_particles": 2.0e4,
         "fail_on_sim": true,
+        "sim_max": "8",
         "template": "run_libe_forces.py"
     },
 
     "submit": {
     	"num_workers": 4,
+        "num_nodes": 2,
     	"cmd_suffix": "--comms local --nworkers $NUM_WORKERS > out.txt 2>&1",
     	"template": "base_submit_template"
     }

--- a/platforms/bebop/platform.json
+++ b/platforms/bebop/platform.json
@@ -2,7 +2,6 @@
 	"calling": {
 		"machine": "'other_hpc_small'",
 		"nthreads": "1",
-		"sim_max": "8"
 	},
 
 	"submit": {
@@ -12,6 +11,5 @@
 		"project": "COMPASSOPT",
 		"do_plots": "false",
 		"plot_dir": "..",
-		"num_nodes": 2
 	}
 }

--- a/platforms/bebop/platform.json
+++ b/platforms/bebop/platform.json
@@ -1,8 +1,17 @@
 {
-	"job_name": "libE_test",
-	"job_wallclock_minutes": 30,
-	"node_type": "knlall",
-	"project": "COMPASSOPT",
-	"do_plots": "false",
-	"plot_dir": ".."
+	"calling": {
+		"machine": "'other_hpc_small'",
+		"nthreads": "1",
+		"sim_max": "8"
+	},
+
+	"submit": {
+		"job_name": "libE_test",
+		"job_wallclock_minutes": 30,
+		"node_type": "knlall",
+		"project": "COMPASSOPT",
+		"do_plots": "false",
+		"plot_dir": "..",
+		"num_nodes": 2
+	}
 }

--- a/platforms/bebop/warpx/MPI_central.json
+++ b/platforms/bebop/warpx/MPI_central.json
@@ -1,9 +1,7 @@
 {
     "calling": {
         "gen_type": "'aposmm'",
-        "machine": "'other_hpc_small'",
         "mpi_disable_mprobes": true,
-        "nthreads": "1",
         "sim_max": 16,
         "template": "run_libensemble_on_warpx.py"
     },

--- a/platforms/bebop/warpx/MPI_central_zero_resource_workers.json
+++ b/platforms/bebop/warpx/MPI_central_zero_resource_workers.json
@@ -1,7 +1,6 @@
 {
     "calling": {
         "gen_type": "'aposmm'",
-        "machine": "'other_hpc_small'",
         "mpi_disable_mprobes": true,
         "zero_resource_workers": 1,
         "nthreads": "1",

--- a/platforms/bebop/warpx/MPI_central_zero_resource_workers.json
+++ b/platforms/bebop/warpx/MPI_central_zero_resource_workers.json
@@ -3,7 +3,6 @@
         "gen_type": "'aposmm'",
         "mpi_disable_mprobes": true,
         "zero_resource_workers": 1,
-        "nthreads": "1",
         "sim_max": 16,
         "template": "run_libensemble_on_warpx.py"
     },

--- a/platforms/bridges/forces/MPI_central_3n_4w.json
+++ b/platforms/bridges/forces/MPI_central_3n_4w.json
@@ -1,6 +1,5 @@
 {
 	"calling": {
-		"mpi_exctr_args": "auto_resources=True, central_mode=True",
 		"sim_max": 8,
 		"mpi_disable_mprobes": true,
 		"template": "run_libe_forces.py"

--- a/platforms/bridges/forces/MPI_central_3n_4w.json
+++ b/platforms/bridges/forces/MPI_central_3n_4w.json
@@ -1,16 +1,12 @@
 {
 	"calling": {
-		"use_balsam": false,
-		"persis_gen": false,
 		"mpi_exctr_args": "auto_resources=True, central_mode=True",
-		"num_sim_particles": 2.0e4,
 		"sim_max": 8,
 		"mpi_disable_mprobes": true,
 		"template": "run_libe_forces.py"
 	},
 
 	"submit": {
-		"num_workers": 4,
 		"num_nodes": 3,
 		"exports": ["export I_MPI_FABRICS=shm:tmi"],
 		"cmd_prefix": "mpirun -np $(($NUM_WORKERS+1)) -ppn $(($NUM_WORKERS+1))",

--- a/platforms/bridges/forces/MPI_central_3n_4w.json
+++ b/platforms/bridges/forces/MPI_central_3n_4w.json
@@ -7,6 +7,7 @@
 
 	"submit": {
 		"num_nodes": 3,
+		"num_workers": 4,
 		"exports": ["export I_MPI_FABRICS=shm:tmi"],
 		"cmd_prefix": "mpirun -np $(($NUM_WORKERS+1)) -ppn $(($NUM_WORKERS+1))",
 		"template": "base_submit_template"

--- a/platforms/bridges/forces/MPI_central_5n_4w.json
+++ b/platforms/bridges/forces/MPI_central_5n_4w.json
@@ -1,7 +1,5 @@
 {
 	"calling": {
-		"mpi_exctr_args": "auto_resources=True, central_mode=True",
-		"num_sim_particles": 2.0e4,
 		"sim_max": 8,
 		"mpi_disable_mprobes": true,
 		"template": "run_libe_forces.py"

--- a/platforms/bridges/forces/MPI_central_5n_4w.json
+++ b/platforms/bridges/forces/MPI_central_5n_4w.json
@@ -7,6 +7,7 @@
 
 	"submit": {
 		"num_nodes": 5,
+		"num_workers": 4,
 		"cmd_prefix": "mpirun -np $(($NUM_WORKERS+1)) -ppn $(($NUM_WORKERS+1))",
 		"template": "base_submit_template"
 	}

--- a/platforms/bridges/forces/MPI_central_5n_4w.json
+++ b/platforms/bridges/forces/MPI_central_5n_4w.json
@@ -1,7 +1,5 @@
 {
 	"calling": {
-		"use_balsam": false,
-		"persis_gen": false,
 		"mpi_exctr_args": "auto_resources=True, central_mode=True",
 		"num_sim_particles": 2.0e4,
 		"sim_max": 8,
@@ -10,7 +8,6 @@
 	},
 
 	"submit": {
-		"num_workers": 4,
 		"num_nodes": 5,
 		"cmd_prefix": "mpirun -np $(($NUM_WORKERS+1)) -ppn $(($NUM_WORKERS+1))",
 		"template": "base_submit_template"

--- a/platforms/bridges/forces/mproc_central_3n_4w.json
+++ b/platforms/bridges/forces/mproc_central_3n_4w.json
@@ -1,7 +1,5 @@
 {
     "calling": {
-        "mpi_exctr_args": "auto_resources=True, central_mode=True",
-        "num_sim_particles": 2.0e4,
         "sim_max": 8,
         "template": "run_libe_forces.py"
     },

--- a/platforms/bridges/forces/mproc_central_3n_4w.json
+++ b/platforms/bridges/forces/mproc_central_3n_4w.json
@@ -1,7 +1,5 @@
 {
     "calling": {
-        "use_balsam": false,
-        "persis_gen": false,
         "mpi_exctr_args": "auto_resources=True, central_mode=True",
         "num_sim_particles": 2.0e4,
         "sim_max": 8,
@@ -9,7 +7,6 @@
     },
 
     "submit": {
-    	"num_workers": 4,
     	"num_nodes": 3,
     	"cmd_suffix": "--comms local --nworkers $NUM_WORKERS > out.txt 2>&1",
     	"template": "base_submit_template"

--- a/platforms/bridges/forces/mproc_central_3n_4w.json
+++ b/platforms/bridges/forces/mproc_central_3n_4w.json
@@ -6,6 +6,7 @@
 
     "submit": {
     	"num_nodes": 3,
+        "num_workers": 4,
     	"cmd_suffix": "--comms local --nworkers $NUM_WORKERS > out.txt 2>&1",
     	"template": "base_submit_template"
     }

--- a/platforms/bridges/forces/mproc_fail_sim.json
+++ b/platforms/bridges/forces/mproc_fail_sim.json
@@ -7,6 +7,7 @@
 
     "submit": {
     	"num_nodes": 2,
+        "num_workers": 4,
     	"cmd_suffix": "--comms local --nworkers $NUM_WORKERS > out.txt 2>&1",
     	"template": "base_submit_template"
     }

--- a/platforms/bridges/forces/mproc_fail_sim.json
+++ b/platforms/bridges/forces/mproc_fail_sim.json
@@ -1,7 +1,5 @@
 {
     "calling": {
-        "mpi_exctr_args": "auto_resources=True, central_mode=True",
-        "num_sim_particles": 2.0e4,
         "sim_max": 8,
         "fail_on_sim": true,
         "template": "run_libe_forces.py"

--- a/platforms/bridges/forces/mproc_fail_sim.json
+++ b/platforms/bridges/forces/mproc_fail_sim.json
@@ -1,7 +1,5 @@
 {
     "calling": {
-        "use_balsam": false,
-        "persis_gen": false,
         "mpi_exctr_args": "auto_resources=True, central_mode=True",
         "num_sim_particles": 2.0e4,
         "sim_max": 8,
@@ -10,7 +8,6 @@
     },
 
     "submit": {
-    	"num_workers": 4,
     	"num_nodes": 2,
     	"cmd_suffix": "--comms local --nworkers $NUM_WORKERS > out.txt 2>&1",
     	"template": "base_submit_template"

--- a/platforms/bridges/platform.json
+++ b/platforms/bridges/platform.json
@@ -1,8 +1,15 @@
 {
-	"job_name": "libE_test",
-	"job_wallclock_minutes": 20,
-	"node_type": "RM",
-	"project": "msz3a9p",
-	"do_plots": "false",
-	"plot_dir": ".."
+	"calling": {
+		"NOT_USED": "not used"
+	},
+
+	"submit": {
+		"job_name": "libE_test",
+		"job_wallclock_minutes": 20,
+		"node_type": "RM",
+		"num_workers": 4,
+		"project": "msz3a9p",
+		"do_plots": "false",
+		"plot_dir": ".."
+	}
 }

--- a/platforms/bridges/platform.json
+++ b/platforms/bridges/platform.json
@@ -1,6 +1,7 @@
 {
 	"calling": {
-		"NOT_USED": "not used"
+		"mpi_exctr_args": "auto_resources=True, central_mode=True",
+		"num_sim_particles": 2.0e4
 	},
 
 	"submit": {

--- a/platforms/bridges/platform.json
+++ b/platforms/bridges/platform.json
@@ -8,7 +8,6 @@
 		"job_name": "libE_test",
 		"job_wallclock_minutes": 20,
 		"node_type": "RM",
-		"num_workers": 4,
 		"project": "msz3a9p",
 		"do_plots": "false",
 		"plot_dir": ".."

--- a/platforms/bridges/warpx/MPI_central.json
+++ b/platforms/bridges/warpx/MPI_central.json
@@ -7,7 +7,6 @@
     },
 
     "submit": {
-    	"num_workers": 4,
     	"num_nodes": 2,
     	"exports": ["export I_MPI_FABRICS=shm:tmi"],
     	"cmd_prefix": "mpirun -np $(($NUM_WORKERS+1)) -ppn $(($NUM_WORKERS+1))",

--- a/platforms/bridges/warpx/MPI_central.json
+++ b/platforms/bridges/warpx/MPI_central.json
@@ -8,6 +8,7 @@
 
     "submit": {
     	"num_nodes": 2,
+        "num_workers": 4,
     	"exports": ["export I_MPI_FABRICS=shm:tmi"],
     	"cmd_prefix": "mpirun -np $(($NUM_WORKERS+1)) -ppn $(($NUM_WORKERS+1))",
     	"template": "base_submit_template"

--- a/platforms/cori/forces/MPI_129n_128w.json
+++ b/platforms/cori/forces/MPI_129n_128w.json
@@ -1,6 +1,5 @@
 {
     "calling": {
-        "mpi_exctr_args": "auto_resources=True, central_mode=True",
         "num_sim_particles": 1e5,
         "sim_max": 512,
         "template": "run_libe_forces.py"

--- a/platforms/cori/forces/MPI_129n_128w.json
+++ b/platforms/cori/forces/MPI_129n_128w.json
@@ -1,7 +1,5 @@
 {
     "calling": {
-        "use_balsam": false,
-        "persis_gen": false,
         "mpi_exctr_args": "auto_resources=True, central_mode=True",
         "num_sim_particles": 1e5,
         "sim_max": 512,

--- a/platforms/cori/forces/MPI_5n_2w.json
+++ b/platforms/cori/forces/MPI_5n_2w.json
@@ -1,6 +1,5 @@
 {
     "calling": {
-        "mpi_exctr_args": "auto_resources=True, central_mode=True",
         "num_sim_particles": 2.0e4,
         "sim_max": 8,
         "template": "run_libe_forces.py"

--- a/platforms/cori/forces/MPI_5n_2w.json
+++ b/platforms/cori/forces/MPI_5n_2w.json
@@ -1,7 +1,5 @@
 {
     "calling": {
-        "use_balsam": false,
-        "persis_gen": false,
         "mpi_exctr_args": "auto_resources=True, central_mode=True",
         "num_sim_particles": 2.0e4,
         "sim_max": 8,

--- a/platforms/cori/forces/MPI_5n_4w.json
+++ b/platforms/cori/forces/MPI_5n_4w.json
@@ -1,6 +1,5 @@
 {
     "calling": {
-        "mpi_exctr_args": "auto_resources=True, central_mode=True",
         "num_sim_particles": 2.0e4,
         "sim_max": 8,
         "template": "run_libe_forces.py"

--- a/platforms/cori/forces/MPI_5n_4w.json
+++ b/platforms/cori/forces/MPI_5n_4w.json
@@ -1,7 +1,5 @@
 {
     "calling": {
-        "use_balsam": false,
-        "persis_gen": false,
         "mpi_exctr_args": "auto_resources=True, central_mode=True",
         "num_sim_particles": 2.0e4,
         "sim_max": 8,

--- a/platforms/cori/forces/MPI_5n_4w_fail_sim.json
+++ b/platforms/cori/forces/MPI_5n_4w_fail_sim.json
@@ -1,6 +1,5 @@
 {
     "calling": {
-        "mpi_exctr_args": "auto_resources=True, central_mode=True",
         "num_sim_particles": 2.0e4,
         "sim_max": 8,
         "fail_on_sim": true,

--- a/platforms/cori/forces/MPI_5n_4w_fail_sim.json
+++ b/platforms/cori/forces/MPI_5n_4w_fail_sim.json
@@ -1,7 +1,5 @@
 {
     "calling": {
-        "use_balsam": false,
-        "persis_gen": false,
         "mpi_exctr_args": "auto_resources=True, central_mode=True",
         "num_sim_particles": 2.0e4,
         "sim_max": 8,

--- a/platforms/cori/forces/MPI_5n_4w_fail_submit.json
+++ b/platforms/cori/forces/MPI_5n_4w_fail_submit.json
@@ -1,6 +1,5 @@
 {
     "calling": {
-        "mpi_exctr_args": "auto_resources=True, central_mode=True",
         "num_sim_particles": 2.0e4,
         "sim_max": 8,
         "fail_on_submit": true,

--- a/platforms/cori/forces/MPI_5n_4w_fail_submit.json
+++ b/platforms/cori/forces/MPI_5n_4w_fail_submit.json
@@ -1,7 +1,5 @@
 {
     "calling": {
-        "use_balsam": false,
-        "persis_gen": false,
         "mpi_exctr_args": "auto_resources=True, central_mode=True",
         "num_sim_particles": 2.0e4,
         "sim_max": 8,

--- a/platforms/cori/forces/mproc_129n_128w.json
+++ b/platforms/cori/forces/mproc_129n_128w.json
@@ -1,8 +1,5 @@
 {
     "calling": {
-        "use_balsam": false,
-        "persis_gen": false,
-        "mpi_exctr_args": "auto_resources=True, central_mode=True",
         "num_sim_particles": 1e5,
         "sim_max": 512,
         "template": "run_libe_forces.py"

--- a/platforms/cori/forces/mproc_5n_2w.json
+++ b/platforms/cori/forces/mproc_5n_2w.json
@@ -1,6 +1,5 @@
 {
     "calling": {
-        "mpi_exctr_args": "auto_resources=True, central_mode=True",
         "num_sim_particles": 2.0e4,
         "sim_max": 8,
         "template": "run_libe_forces.py"

--- a/platforms/cori/forces/mproc_5n_2w.json
+++ b/platforms/cori/forces/mproc_5n_2w.json
@@ -1,7 +1,5 @@
 {
     "calling": {
-        "use_balsam": false,
-        "persis_gen": false,
         "mpi_exctr_args": "auto_resources=True, central_mode=True",
         "num_sim_particles": 2.0e4,
         "sim_max": 8,

--- a/platforms/cori/forces/mproc_5n_4w.json
+++ b/platforms/cori/forces/mproc_5n_4w.json
@@ -1,6 +1,5 @@
 {
     "calling": {
-        "mpi_exctr_args": "auto_resources=True, central_mode=True",
         "num_sim_particles": 2.0e4,
         "sim_max": 8,
         "template": "run_libe_forces.py"

--- a/platforms/cori/forces/mproc_5n_4w.json
+++ b/platforms/cori/forces/mproc_5n_4w.json
@@ -1,7 +1,5 @@
 {
     "calling": {
-        "use_balsam": false,
-        "persis_gen": false,
         "mpi_exctr_args": "auto_resources=True, central_mode=True",
         "num_sim_particles": 2.0e4,
         "sim_max": 8,

--- a/platforms/cori/forces/mproc_5n_4w_fail_sim.json
+++ b/platforms/cori/forces/mproc_5n_4w_fail_sim.json
@@ -1,6 +1,5 @@
 {
     "calling": {
-        "mpi_exctr_args": "auto_resources=True, central_mode=True",
         "num_sim_particles": 2.0e4,
         "sim_max": 8,
         "fail_on_sim": true,

--- a/platforms/cori/forces/mproc_5n_4w_fail_sim.json
+++ b/platforms/cori/forces/mproc_5n_4w_fail_sim.json
@@ -1,7 +1,5 @@
 {
     "calling": {
-        "use_balsam": false,
-        "persis_gen": false,
         "mpi_exctr_args": "auto_resources=True, central_mode=True",
         "num_sim_particles": 2.0e4,
         "sim_max": 8,

--- a/platforms/cori/platform.json
+++ b/platforms/cori/platform.json
@@ -1,10 +1,17 @@
 {
-	"job_name": "libE_test",
-	"queue": "debug",
-	"project": "m3353",
-	"do_plots": "false",
-	"plot_dir": "..",
-    "job_wallclock_minutes": 30,
-    "conda_env_name": "libe_common_intel_py3.6",
-	"node_type": "knl"
+	"calling": {
+		"persis_gen": false,
+		"mpi_exctr_args": "auto_resources=True, central_mode=True"
+	},
+
+	"submit": {
+		"job_name": "libE_test",
+		"queue": "debug",
+		"project": "m3353",
+		"do_plots": "false",
+		"plot_dir": "..",
+	    "job_wallclock_minutes": 30,
+	    "conda_env_name": "libe_common_intel_py3.6",
+		"node_type": "knl"
+	}
 }

--- a/platforms/summit/forces/mproc_central_128w_128n.json
+++ b/platforms/summit/forces/mproc_central_128w_128n.json
@@ -1,6 +1,5 @@
 {
     "calling": {
-        "use_balsam": false,
         "persis_gen": false,
         "mpi_exctr_args": "auto_resources=True, central_mode=True",
         "num_sim_particles": 1e5,

--- a/platforms/summit/forces/mproc_central_128w_128n.json
+++ b/platforms/summit/forces/mproc_central_128w_128n.json
@@ -1,7 +1,6 @@
 {
     "calling": {
         "persis_gen": false,
-        "mpi_exctr_args": "auto_resources=True, central_mode=True",
         "num_sim_particles": 1e5,
         "sim_max": 512,
         "template": "run_libe_forces.py"

--- a/platforms/summit/forces/mproc_central_4w_4n.json
+++ b/platforms/summit/forces/mproc_central_4w_4n.json
@@ -1,7 +1,6 @@
 {
     "calling": {
         "persis_gen": false,
-        "mpi_exctr_args": "auto_resources=True, central_mode=True",
         "num_sim_particles": 1e5,
         "sim_max": 8,
         "template": "run_libe_forces.py"

--- a/platforms/summit/forces/mproc_central_4w_4n.json
+++ b/platforms/summit/forces/mproc_central_4w_4n.json
@@ -1,6 +1,5 @@
 {
     "calling": {
-        "use_balsam": false,
         "persis_gen": false,
         "mpi_exctr_args": "auto_resources=True, central_mode=True",
         "num_sim_particles": 1e5,

--- a/platforms/summit/forces/mproc_central_4w_4n_fail_sim.json
+++ b/platforms/summit/forces/mproc_central_4w_4n_fail_sim.json
@@ -1,6 +1,5 @@
 {
     "calling": {
-        "use_balsam": false,
         "persis_gen": false,
         "mpi_exctr_args": "auto_resources=True, central_mode=True",
         "num_sim_particles": 1e5,

--- a/platforms/summit/forces/mproc_central_4w_4n_fail_sim.json
+++ b/platforms/summit/forces/mproc_central_4w_4n_fail_sim.json
@@ -1,7 +1,6 @@
 {
     "calling": {
         "persis_gen": false,
-        "mpi_exctr_args": "auto_resources=True, central_mode=True",
         "num_sim_particles": 1e5,
         "sim_max": 8,
         "fail_on_sim": true,

--- a/platforms/summit/forces/mproc_central_4w_8n.json
+++ b/platforms/summit/forces/mproc_central_4w_8n.json
@@ -1,7 +1,6 @@
 {
     "calling": {
         "persis_gen": false,
-        "mpi_exctr_args": "auto_resources=True, central_mode=True",
         "num_sim_particles": 1e5,
         "sim_max": 8,
         "template": "run_libe_forces.py"

--- a/platforms/summit/forces/mproc_central_4w_8n.json
+++ b/platforms/summit/forces/mproc_central_4w_8n.json
@@ -1,6 +1,5 @@
 {
     "calling": {
-        "use_balsam": false,
         "persis_gen": false,
         "mpi_exctr_args": "auto_resources=True, central_mode=True",
         "num_sim_particles": 1e5,

--- a/platforms/summit/platform.json
+++ b/platforms/summit/platform.json
@@ -1,6 +1,7 @@
 {
 	"calling": {
-		"NOT_USED": "not used"
+		"mpi_exctr_args": "auto_resources=True, central_mode=True",
+		"machine": "'summit'"
 	},
 
 	"submit": {

--- a/platforms/summit/platform.json
+++ b/platforms/summit/platform.json
@@ -1,10 +1,16 @@
 {
-	"job_name": "libe_mproc",
-	"project": "csc314",
-	"do_plots": "false",
-	"plot_dir": "../../plot_scripts",
-    "job_wallclock_minutes": 20,
-	"libe_wallclock": 15,
-    "conda_env_name": "libe-gcc",
-	"alloc_flags": "smt1"
+	"calling": {
+		"NOT_USED": "not used"
+	},
+
+	"submit": {
+		"job_name": "libe_mproc",
+		"project": "csc314",
+		"do_plots": "false",
+		"plot_dir": "../../plot_scripts",
+	    "job_wallclock_minutes": 20,
+		"libe_wallclock": 15,
+	    "conda_env_name": "libe-gcc",
+		"alloc_flags": "smt1"
+	}
 }

--- a/platforms/summit/warpx/aposmm_mproc_12w_4n.json
+++ b/platforms/summit/warpx/aposmm_mproc_12w_4n.json
@@ -1,7 +1,6 @@
 {
     "calling": {
         "gen_type": "'aposmm'",
-        "machine": "'summit'",
         "template": "run_libensemble_on_warpx.py",
         "e_args": "'-n 2 -a 1 -g 1 -c 1 --bind=packed:1 --smpiargs=\"-gpu\"'",
         "nthreads": "1",

--- a/platforms/summit/warpx/aposmm_mproc_12w_4n_portopts.json
+++ b/platforms/summit/warpx/aposmm_mproc_12w_4n_portopts.json
@@ -1,7 +1,6 @@
 {
     "calling": {
         "gen_type": "'aposmm'",
-        "machine": "'summit'",
         "template": "run_libensemble_on_warpx.py",
         "num_nodes": "1",
         "ranks_per_node": "2",

--- a/platforms/summit/warpx/aposmm_mproc_24w_4n.json
+++ b/platforms/summit/warpx/aposmm_mproc_24w_4n.json
@@ -1,7 +1,6 @@
 {
     "calling": {
         "gen_type": "'aposmm'",
-        "machine": "'summit'",
         "template": "run_libensemble_on_warpx.py",
         "e_args": "'-n 1 -a 1 -g 1 -c 1 --bind=packed:1 --smpiargs=\"-gpu\"'",
         "nthreads": "1",

--- a/platforms/summit/warpx/aposmm_mproc_4w_4n.json
+++ b/platforms/summit/warpx/aposmm_mproc_4w_4n.json
@@ -1,7 +1,6 @@
 {
     "calling": {
         "gen_type": "'aposmm'",
-        "machine": "'summit'",
         "template": "run_libensemble_on_warpx.py",
         "e_args": "'-n 6 -a 1 -g 1 -c 1 --bind=packed:1 --smpiargs=\"-gpu\"'",
         "nthreads": "1",

--- a/platforms/summit/warpx/aposmm_mproc_4w_8n.json
+++ b/platforms/summit/warpx/aposmm_mproc_4w_8n.json
@@ -1,7 +1,6 @@
 {
     "calling": {
         "gen_type": "'aposmm'",
-        "machine": "'summit'",
         "template": "run_libensemble_on_warpx.py",
         "e_args": "'-n 12 -a 1 -g 1 -c 1 --bind=packed:1 --smpiargs=\"-gpu\"'",
         "nthreads": "1",

--- a/platforms/summit/warpx/aposmm_mproc_4w_8n_portops.json
+++ b/platforms/summit/warpx/aposmm_mproc_4w_8n_portops.json
@@ -1,7 +1,6 @@
 {
     "calling": {
         "gen_type": "'aposmm'",
-        "machine": "'summit'",
         "template": "run_libensemble_on_warpx.py",
         "num_procs": "12",
         "e_args": "'-a 1 -g 1 -c 1 --bind=packed:1 --smpiargs=\"-gpu\"'",

--- a/platforms/summit/warpx/aposmm_mproc_zrw_13w_4n_portopts.json
+++ b/platforms/summit/warpx/aposmm_mproc_zrw_13w_4n_portopts.json
@@ -1,7 +1,6 @@
 {
     "calling": {
         "gen_type": "'aposmm'",
-        "machine": "'summit'",
         "zero_resource_workers": 1,
         "template": "run_libensemble_on_warpx.py",
         "num_nodes": "1",

--- a/platforms/summit/warpx/aposmm_mproc_zrw_25w_4n.json
+++ b/platforms/summit/warpx/aposmm_mproc_zrw_25w_4n.json
@@ -1,7 +1,6 @@
 {
     "calling": {
         "gen_type": "'aposmm'",
-        "machine": "'summit'",
         "zero_resource_workers": 1,
         "template": "run_libensemble_on_warpx.py",
         "e_args": "'-n 1 -a 1 -g 1 -c 1 --bind=packed:1 --smpiargs=\"-gpu\"'",

--- a/platforms/summit/warpx/aposmm_mproc_zrw_65w_128n_portops.json
+++ b/platforms/summit/warpx/aposmm_mproc_zrw_65w_128n_portops.json
@@ -1,7 +1,6 @@
 {
     "calling": {
         "gen_type": "'aposmm'",
-        "machine": "'summit'",
         "zero_resource_workers": 1,
         "template": "run_libensemble_on_warpx.py",
         "num_procs": "12",

--- a/platforms/theta/forces/MPI_balsam_central_127w_129n.json
+++ b/platforms/theta/forces/MPI_balsam_central_127w_129n.json
@@ -1,7 +1,6 @@
 {
     "calling": {
         "use_balsam": true,
-        "persis_gen": false,
         "balsam_exctr_args": "auto_resources=True, central_mode=True",
         "mpi_exctr_args": "auto_resources=True, central_mode=True",
         "num_sim_particles": 1e5,

--- a/platforms/theta/forces/MPI_balsam_central_127w_129n_fail_sim.json
+++ b/platforms/theta/forces/MPI_balsam_central_127w_129n_fail_sim.json
@@ -1,7 +1,6 @@
 {
     "calling": {
         "use_balsam": true,
-        "persis_gen": false,
         "balsam_exctr_args": "auto_resources=True, central_mode=True",
         "mpi_exctr_args": "auto_resources=True, central_mode=True",
         "num_sim_particles": 1e5,

--- a/platforms/theta/forces/MPI_balsam_central_4w_4n.json
+++ b/platforms/theta/forces/MPI_balsam_central_4w_4n.json
@@ -1,7 +1,6 @@
 {
     "calling": {
         "use_balsam": true,
-        "persis_gen": false,
         "balsam_exctr_args": "auto_resources=True, central_mode=True",
         "mpi_exctr_args": "auto_resources=True, central_mode=False",
         "num_sim_particles": 1e5,

--- a/platforms/theta/forces/MPI_balsam_central_4w_4n_fail_submit.json
+++ b/platforms/theta/forces/MPI_balsam_central_4w_4n_fail_submit.json
@@ -1,7 +1,6 @@
 {
     "calling": {
         "use_balsam": true,
-        "persis_gen": false,
         "balsam_exctr_args": "auto_resources=True, central_mode=True",
         "mpi_exctr_args": "auto_resources=True, central_mode=False",
         "num_sim_particles": 1e5,

--- a/platforms/theta/forces/mproc_MOM_central_128w_128n.json
+++ b/platforms/theta/forces/mproc_MOM_central_128w_128n.json
@@ -1,7 +1,6 @@
 {
     "calling": {
         "use_balsam": false,
-        "persis_gen": false,
         "mpi_exctr_args": "auto_resources=True, central_mode=True",
         "num_sim_particles": 1e5,
         "sim_max": 512,

--- a/platforms/theta/forces/mproc_MOM_central_4w_8n.json
+++ b/platforms/theta/forces/mproc_MOM_central_4w_8n.json
@@ -1,7 +1,6 @@
 {
     "calling": {
         "use_balsam": false,
-        "persis_gen": false,
         "mpi_exctr_args": "auto_resources=True, central_mode=True",
         "num_sim_particles": 1e5,
         "sim_max": 8,

--- a/platforms/theta/forces/mproc_MOM_central_4w_8n_fail_sim.json
+++ b/platforms/theta/forces/mproc_MOM_central_4w_8n_fail_sim.json
@@ -1,7 +1,6 @@
 {
     "calling": {
         "use_balsam": false,
-        "persis_gen": false,
         "mpi_exctr_args": "auto_resources=True, central_mode=True",
         "num_sim_particles": 1e5,
         "sim_max": 8,

--- a/platforms/theta/forces/mproc_MOM_central_4w_8n_fail_submit.json
+++ b/platforms/theta/forces/mproc_MOM_central_4w_8n_fail_submit.json
@@ -1,7 +1,6 @@
 {
     "calling": {
         "use_balsam": false,
-        "persis_gen": false,
         "mpi_exctr_args": "auto_resources=True, central_mode=True",
         "num_sim_particles": 1e5,
         "sim_max": 8,

--- a/platforms/theta/platform.json
+++ b/platforms/theta/platform.json
@@ -1,6 +1,7 @@
 {
 	"calling": {
         "nthreads": "1",
+		"persis_gen": false
 	},
 
 	"submit": {

--- a/platforms/theta/platform.json
+++ b/platforms/theta/platform.json
@@ -1,10 +1,16 @@
 {
-    "job_wallclock_minutes": 40,
-	"project": "CSC250STMS07",
-	"do_plots": "false",
-    "do_balsam_plots": "false",
-	"plot_dir": "../../../",
-    "balsam_plot_dir": "../../../",
-    "balsam_db_name": "dbase_pg_forces_large",
-    "conda_env_name": "balsam_dbindel_with_deap"
+	"calling": {
+        "nthreads": "1",
+	},
+
+	"submit": {
+        "job_wallclock_minutes": 40,
+	    "project": "CSC250STMS07",
+    	"do_plots": "false",
+        "do_balsam_plots": "false",
+    	"plot_dir": "../../../",
+        "balsam_plot_dir": "../../../",
+        "balsam_db_name": "dbase_pg_forces_large",
+        "conda_env_name": "balsam_dbindel_with_deap"
+    }
 }

--- a/platforms/theta/warpx/MPI_balsam_central_128w_256n.json
+++ b/platforms/theta/warpx/MPI_balsam_central_128w_256n.json
@@ -3,7 +3,6 @@
         "gen_type": "'aposmm'",
         "machine": "'other_hpc_large'",
         "use_balsam": true,
-        "nthreads": "1",
         "sim_max": 256,
         "template": "run_libensemble_on_warpx.py"
     },

--- a/platforms/theta/warpx/mproc_MOM_central_128w_256n.json
+++ b/platforms/theta/warpx/mproc_MOM_central_128w_256n.json
@@ -2,7 +2,6 @@
     "calling": {
         "gen_type": "'aposmm'",
         "machine": "'other_hpc_large'",
-        "nthreads": "1",
         "sim_max": 16,
         "template": "run_libensemble_on_warpx.py"
     },

--- a/platforms/theta/warpx/mproc_MOM_central_4w_8n.json
+++ b/platforms/theta/warpx/mproc_MOM_central_4w_8n.json
@@ -2,7 +2,6 @@
     "calling": {
         "gen_type": "'aposmm'",
         "machine": "'other_hpc_small'",
-        "nthreads": "1",
         "sim_max": 16,
         "template": "run_libensemble_on_warpx.py"
     },

--- a/platforms/theta/warpx/mproc_MOM_central_zero_resource_workers_5w_8n.json
+++ b/platforms/theta/warpx/mproc_MOM_central_zero_resource_workers_5w_8n.json
@@ -3,7 +3,6 @@
         "gen_type": "'aposmm'",
         "machine": "'other_hpc_small'",
         "zero_resource_workers": 1,
-        "nthreads": "1",
         "sim_max": 16,
         "template": "run_libensemble_on_warpx.py"
     },

--- a/templater
+++ b/templater
@@ -141,7 +141,8 @@ if __name__ == '__main__':
             for variant in test_variants:  # differentiated by num_nodes, comms, etc.
                 calling_values, submit_values = get_config_values(in_test_dir, variant)
                 single_test = {"test": calling_values['template']}
-                submit_values = {**single_test, **platform_values, **submit_values}
+                submit_values = {**single_test, **platform_values["submit"], **submit_values}
+                calling_values = {**platform_values["calling"], **calling_values}
 
                 out_test_dir = make_test_dir(out_platform_dir, variant)
 


### PR DESCRIPTION
``platform.json`` is now also divided into ``"calling"`` and ``"submit"`` sections. Note the following new points from the README:

1. Parameters in ``platform.json`` don't necessarily have to match Jinja syntax in each template. A value can be included in ``platform.json`` for a Forces calling script, but that value's corresponding Jinja syntax isn't required to be in a WarpX calling script.
2. Parameters in specific test cases can also appear in ``platform.json``, and will override. Suppose for all test cases but one on Bebop you want ``'sim_max'`` to be 8. ``"sim_max": 8`` can be added to ``platform.json`` and ``"sim_max": 16`` can be added to the other config file.

These changes should help make test configurations less redundant. Additional suggestions are appreciated.

This is also an important step for deprecating ``all_machine_specs``, since we can specify the WarpX application on a per-platform basis within ``platform.json``.